### PR TITLE
Minor correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are using tinted-shell for point number 2, we suggest using
 
 ## Usage
 
-Clone the repo locally and execute the script with your posix compliant
+Clone the repo locally and execute the script with your Bourne-like
 shell (sh, bash, zsh, etc).
 
 ```sh


### PR DESCRIPTION
Zsh is not actually POSIX-compliant (e.g. it's missing word-splitting), even though it's close enough for maybe 95% of scripts.