### PR TITLE
feat(sh): cleanup legacy values

### DIFF
--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -3,7 +3,6 @@
 # Scheme name: {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-export BASE16_THEME={{scheme-slug}}
 
 color00="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00 - Black
 color01="{{base08-hex-r}}/{{base08-hex-g}}/{{base08-hex-b}}" # Base 08 - Red
@@ -130,6 +129,11 @@ unset color20
 unset color21
 unset color_foreground
 unset color_background
+legacy_env="$([ -n "$BASH_VERSION" ] && set -o posix; export -p | sed 's/^export[[:space:]]\+\([a-zA-Z0-9_]\+\)=.*$/\1/' | grep -e 'BASE16_THEME' -e 'BASE24_THEME' -e 'TINTED8_THEME' -e 'BASE16_COLOR_' -e 'BASE24_COLOR_' -e 'TINTED8_COLOR_')" && [ -n "$legacy_env" ] && unset $legacy_env
+unset legacy_env
+
+# Set theme
+export BASE16_THEME={{scheme-slug}}
 
 # Optionally export variables
 if [ -n "$TINTED_SHELL_ENABLE_BASE16_VARS" ] || [ -n "$BASE16_SHELL_ENABLE_VARS" ]; then

--- a/templates/base24.mustache
+++ b/templates/base24.mustache
@@ -3,7 +3,6 @@
 # Scheme name: {{scheme-name}}
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-export BASE24_THEME="{{scheme-slug}}"
 
 color00="{{base00-hex-r}}/{{base00-hex-g}}/{{base00-hex-b}}" # Base 00 - Black
 color01="{{base08-hex-r}}/{{base08-hex-g}}/{{base08-hex-b}}" # Base 08 - Red
@@ -131,6 +130,11 @@ unset color20
 unset color21
 unset color_foreground
 unset color_background
+legacy_env="$([ -n "$BASH_VERSION" ] && set -o posix; export -p | sed 's/^export[[:space:]]\+\([a-zA-Z0-9_]\+\)=.*$/\1/' | grep -e 'BASE16_THEME' -e 'BASE24_THEME' -e 'TINTED8_THEME' -e 'BASE16_COLOR_' -e 'BASE24_COLOR_' -e 'TINTED8_COLOR_')" && [ -n "$legacy_env" ] && unset $legacy_env
+unset legacy_env
+
+# Set theme
+export BASE24_THEME="{{scheme-slug}}"
 
 # Optionally export variables
 if [ -n "$TINTED_SHELL_ENABLE_BASE24_VARS" ]; then

--- a/templates/tinted8.mustache
+++ b/templates/tinted8.mustache
@@ -3,7 +3,6 @@
 # Scheme name: {{scheme.system}} {{scheme.name}}
 # Scheme author: {{scheme.author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
-export TINTED8_THEME="{{scheme.slug}}"
 
 color00="{{palette.black.normal.hex-r}}/{{palette.black.normal.hex-g}}/{{palette.black.normal.hex-b}}"
 color01="{{palette.red.normal.hex-r}}/{{palette.red.normal.hex-g}}/{{palette.red.normal.hex-b}}"
@@ -116,6 +115,11 @@ unset color20
 unset color21
 unset color_foreground
 unset color_background
+legacy_env="$([ -n "$BASH_VERSION" ] && set -o posix; export -p | sed 's/^export[[:space:]]\+\([a-zA-Z0-9_]\+\)=.*$/\1/' | grep -e 'BASE16_THEME' -e 'BASE24_THEME' -e 'TINTED8_THEME' -e 'BASE16_COLOR_' -e 'BASE24_COLOR_' -e 'TINTED8_COLOR_')" && [ -n "$legacy_env" ] && unset $legacy_env
+unset legacy_env
+
+# Set theme
+export TINTED8_THEME="{{scheme.slug}}"
 
 # Optionally export variables
 if [ -n "$TINTED_SHELL_ENABLE_TINTED8_VARS" ]; then


### PR DESCRIPTION
This change align the behavior of previously added fish scripts. Cleanup legacy values (`{SYSTEM}_THEME` or `{SYSTEM}_COLOR_*`) brought from previous shell or tinty command.

See #72 