### PR TITLE
fix(fish): base24 bright color error

### DIFF
--- a/templates/base24-fish.mustache
+++ b/templates/base24-fish.mustache
@@ -13,12 +13,12 @@ set -l color05 "{{base0E-hex-r}}/{{base0E-hex-g}}/{{base0E-hex-b}}" # Base 0E - 
 set -l color06 "{{base0C-hex-r}}/{{base0C-hex-g}}/{{base0C-hex-b}}" # Base 0C - Cyan
 set -l color07 "{{base05-hex-r}}/{{base05-hex-g}}/{{base05-hex-b}}" # Base 05 - White
 set -l color08 "{{base03-hex-r}}/{{base03-hex-g}}/{{base03-hex-b}}" # Base 03 - Bright Black
-set -l color09 "$color01" # Base 08 - Bright Red
-set -l color10 "$color02" # Base 0B - Bright Green
-set -l color11 "$color03" # Base 0A - Bright Yellow
-set -l color12 "$color04" # Base 0D - Bright Blue
-set -l color13 "$color05" # Base 0E - Bright Magenta
-set -l color14 "$color06" # Base 0C - Bright Cyan
+set -l color09 "{{base12-hex-r}}/{{base12-hex-g}}/{{base12-hex-b}}" # Base 12 - Bright Red
+set -l color10 "{{base14-hex-r}}/{{base14-hex-g}}/{{base14-hex-b}}" # Base 14 - Bright Green
+set -l color11 "{{base13-hex-r}}/{{base13-hex-g}}/{{base13-hex-b}}" # Base 13 - Bright Yellow
+set -l color12 "{{base16-hex-r}}/{{base16-hex-g}}/{{base16-hex-b}}" # Base 16 - Bright Blue
+set -l color13 "{{base17-hex-r}}/{{base17-hex-g}}/{{base17-hex-b}}" # Base 17 - Bright Magenta
+set -l color14 "{{base15-hex-r}}/{{base15-hex-g}}/{{base15-hex-b}}" # Base 15 - Bright Cyan
 set -l color15 "{{base07-hex-r}}/{{base07-hex-g}}/{{base07-hex-b}}" # Base 07 - Bright White
 set -l color16 "{{base09-hex-r}}/{{base09-hex-g}}/{{base09-hex-b}}" # Base 09
 set -l color17 "{{base0F-hex-r}}/{{base0F-hex-g}}/{{base0F-hex-b}}" # Base 0F


### PR DESCRIPTION
I copied template form base16-fish and forget to update the bright colors. This should fix the problem.